### PR TITLE
Fix resources path to launch CLI on Windows

### DIFF
--- a/src/com/wakatime/intellij/plugin/Dependencies.java
+++ b/src/com/wakatime/intellij/plugin/Dependencies.java
@@ -31,6 +31,9 @@ public class Dependencies {
                     .replaceAll("%20", " ")
                     .replaceFirst("com" + separator + "wakatime" + separator + "intellij" + separator + "plugin" + separator + "WakaTime.class", "")
                     .replaceFirst("WakaTime.jar!" + separator, "") + "WakaTime-resources";
+            if (System.getProperty("os.name").startsWith("Windows") && resourcesLocation.startsWith("/")) {
+                resourcesLocation = resourcesLocation.substring(1);
+            }
         }
         return Dependencies.resourcesLocation;
     }

--- a/src/com/wakatime/intellij/plugin/WakaTime.java
+++ b/src/com/wakatime/intellij/plugin/WakaTime.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.ResourceBundle;
 
@@ -63,6 +64,8 @@ public class WakaTime implements ApplicationComponent {
         }
 
         if (Dependencies.isPythonInstalled()) {
+            log.debug("Python location: " + Dependencies.getPythonLocation());
+            log.debug("CLI location: " + Dependencies.getCLILocation());
 
             // prompt for apiKey if it does not already exist
             if (ApiKey.getApiKey().equals("")) {
@@ -105,9 +108,10 @@ public class WakaTime implements ApplicationComponent {
         if (isWrite)
             cmds.add("--write");
         try {
+            log.debug("Executing CLI: " + Arrays.toString(cmds.toArray()));
             Runtime.getRuntime().exec(cmds.toArray(new String[cmds.size()]));
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error(e);
         }
     }
 


### PR DESCRIPTION
Hello there. I had to use Windows from time to time, and found out WakaTime PyCharm plugin
didn't work there, silently failing. Everything looked okay, but data was never reported to a server.

I found out that resources location had a slash prepended (i.e. `/C:/Foo/…`) which resulted in silent inability to launch CLI (`pythonw /C:/…` didn't found the script).

This patch fixes it for me.
