### PR TITLE
Use WAKATIME_HOME env

### DIFF
--- a/src/com/wakatime/intellij/plugin/Dependencies.java
+++ b/src/com/wakatime/intellij/plugin/Dependencies.java
@@ -47,6 +47,13 @@ public class Dependencies {
 
     public static String getResourcesLocation() {
         if (Dependencies.resourcesLocation == null) {
+            if (System.getenv("WAKATIME_HOME")) {
+                File appDataFolder = new File(System.getenv("WAKATIME_HOME"));
+                File resourcesFolder = new File(System.getenv("WAKATIME_HOME"));
+                Dependencies.resourcesLocation = resourcesFolder.getAbsolutePath();
+                return Dependencies.resourcesLocation;
+            }
+
             if (isWindows()) {
                 File appDataFolder = new File(System.getenv("APPDATA"));
                 File resourcesFolder = new File(appDataFolder, "WakaTime");


### PR DESCRIPTION
Hey, following up on https://github.com/wakatime/wakatime/issues/73#issuecomment-312964355 - seems that the jetbrains plugin is creating `.wakatime/wakatime-master/` and ignoring WAKATIME_HOME

This is just a start, haven't tested it - not much of a Java person - probably still need to add code to read... I may get around to it eventually, or you can take it from here