### PR TITLE
Add $WAKATIME_BIN environment variable

### DIFF
--- a/src/com/wakatime/intellij/plugin/Dependencies.java
+++ b/src/com/wakatime/intellij/plugin/Dependencies.java
@@ -175,6 +175,14 @@ public class Dependencies {
     }
 
     public static String getCLILocation() {
+        if (System.getenv("WAKATIME_BIN") != null && !System.getenv("WAKATIME_BIN").trim().isEmpty()) {
+            File cliBinary = new File(System.getenv("WAKATIME_BIN"));
+            if (cliBinary.exists()) {
+                WakaTime.log.debug("Using $WAKATIME_BIN as CLI Executable: " + cliBinary);
+                return System.getenv("WAKATIME_BIN");
+            }
+        }
+
         String ext = isWindows() ? ".exe" : "";
         if (!isStandalone()) {
             return combinePaths(getResourcesLocation(), "wakatime-cli-" + platform() + "-" + architecture() + ext);

--- a/src/com/wakatime/intellij/plugin/WakaTime.java
+++ b/src/com/wakatime/intellij/plugin/WakaTime.java
@@ -107,10 +107,17 @@ public class WakaTime implements ApplicationComponent {
                     WakaTime.READY = true;
                     log.info("Finished downloading and installing wakatime-cli.");
                 } else if (Dependencies.isCLIOld()) {
-                    log.info("Upgrading wakatime-cli ...");
-                    Dependencies.installCLI();
-                    WakaTime.READY = true;
-                    log.info("Finished upgrading wakatime-cli.");
+                    if (System.getenv("WAKATIME_BIN") != null && !System.getenv("WAKATIME_BIN").trim().isEmpty()) {
+                        File cliBinary = new File(System.getenv("WAKATIME_BIN"));
+                        if (cliBinary.exists()) {
+                          log.warn("$WAKATIME_BIN is out of date, please update it.")
+                        }
+                    } else {
+                        log.info("Upgrading wakatime-cli ...");
+                        Dependencies.installCLI();
+                        WakaTime.READY = true;
+                        log.info("Finished upgrading wakatime-cli.");
+                    }
                 } else {
                     WakaTime.READY = true;
                     log.info("wakatime-cli is up to date.");

--- a/src/com/wakatime/intellij/plugin/WakaTime.java
+++ b/src/com/wakatime/intellij/plugin/WakaTime.java
@@ -34,11 +34,7 @@ import com.intellij.util.messages.MessageBusConnection;
 import org.jetbrains.annotations.NotNull;
 
 import java.awt.KeyboardFocusManager;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.InputStreamReader;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
+import java.io.*;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -110,7 +106,7 @@ public class WakaTime implements ApplicationComponent {
                     if (System.getenv("WAKATIME_BIN") != null && !System.getenv("WAKATIME_BIN").trim().isEmpty()) {
                         File cliBinary = new File(System.getenv("WAKATIME_BIN"));
                         if (cliBinary.exists()) {
-                          log.warn("$WAKATIME_BIN is out of date, please update it.")
+                          log.warn("$WAKATIME_BIN is out of date, please update it.");
                         }
                     } else {
                         log.info("Upgrading wakatime-cli ...");


### PR DESCRIPTION
On Nixos the auto downloaded wakatime-cli cannot run because Nixos does not store shared libraries in a typical unix location.
I also cannot set $WAKATIME_HOME to a nix managed location with a patched binary because those are read only, so I'd have to manage the API key in my nix config which is public.

I've added a $WAKATIME_BIN environment variable which if set will be used instead of downloading or updating the plugin managed binary.

This might not be the best way of doing this, it's just how I decided to fix my own issue.  Just thought others might also benefit from a variable like this.