### PR TITLE
Update General Troubleshooting Link and Fix IDEs List in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,19 @@ In that case, add this line to your `~/.wakatime.cfg` file:
 
 (`C:\Users\<user>\.wakatime.cfg` on Windows)
 
-For more general troubleshooting information, see [wakatime/wakatime#troubleshooting](https://github.com/wakatime/wakatime#troubleshooting).
+For more general troubleshooting information, see [Wakatime General Troubleshooting](https://wakatime.com/help).
 
-[wakatime]: https://wakatime.com/intellij-idea
-[android studio]: https://wakatime.com/android-studio
-[appcode]: https://wakatime.com/appcode
-[clion]: https://wakatime.com/clion
-[datagrip]: https://wakatime.com/datagrip
-[goland]: https://wakatime.com/goland
-[phpstorm]: https://wakatime.com/phpstorm
-[pycharm]: https://wakatime.com/pycharm
-[rider]: https://wakatime.com/rider
-[rubymine]: https://wakatime.com/rubymine
-[webstorm]: https://wakatime.com/webstorm
+For more information on various IDEs, you can visit the following:
+
+- [intellij-idea](https://wakatime.com/intellij-idea)
+- [Android Studio](https://wakatime.com/android-studio)
+- [AppCode](https://wakatime.com/appcode)
+- [CLion](https://wakatime.com/clion)
+- [DataGrip](https://wakatime.com/datagrip)
+- [GoLand](https://wakatime.com/goland)
+- [PhpStorm](https://wakatime.com/phpstorm)
+- [PyCharm](https://wakatime.com/pycharm)
+- [Rider](https://wakatime.com/rider)
+- [RubyMine](https://wakatime.com/rubymine)
+- [WebStorm](https://wakatime.com/webstorm)
+

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ In that case, add this line to your `~/.wakatime.cfg` file:
 
 (`C:\Users\<user>\.wakatime.cfg` on Windows)
 
-For more general troubleshooting information, see [Wakatime General Troubleshooting](https://wakatime.com/help).
+For more general troubleshooting information, see [WakaTime CLI Troubleshooting](https://wakatime.com/help](https://github.com/wakatime/wakatime-cli/blob/develop/TROUBLESHOOTING.md).
 
-For more information on various IDEs, you can visit the following:
+For more information on various IDEs:
 
 - [intellij-idea](https://wakatime.com/intellij-idea)
 - [Android Studio](https://wakatime.com/android-studio)


### PR DESCRIPTION
### Description:

This PR addresses two issues:

1. **Fixes Broken Troubleshooting Link**: The previous troubleshooting link led to a 404 page. This has been corrected to point to the general troubleshooting page on WakaTime's website.
   
2. **Corrects the Hidden List of IDEs**: The README already included a list of IDEs with WakaTime support, but they were not displaying correctly due to incorrect Markdown formatting. This has been fixed to reveal the list with direct links to their respective pages on WakaTime's website.

#### Changes:

- Updated the broken troubleshooting link to `[Wakatime General Troubleshooting](https://wakatime.com/help)`.
  
- Corrected the Markdown formatting for the list of IDEs to display them with direct links to their pages on WakaTime's website.

#### Related Issues:

Closes [#265](https://github.com/wakatime/jetbrains-wakatime/issues/265)